### PR TITLE
fix non-matching object selector

### DIFF
--- a/jsonUdf.cc
+++ b/jsonUdf.cc
@@ -63,7 +63,7 @@ StringVal JsonGetObject(FunctionContext *context, const StringVal & jsonVal, con
 #define selectValByToken(tok) { \
     rapidjson::Value& va = *currentVal;  \
     rapidjson::Value key(rapidjson::StringRef(tok.c_str())); \
-    if (va.HasMember(key) { \
+    if (va.HasMember(key)) { \
         currentVal = &(va[key]); \
     } else { \
         /* context->AddWarning("no member"); */ \

--- a/jsonUdf.cc
+++ b/jsonUdf.cc
@@ -62,8 +62,9 @@ StringVal JsonGetObject(FunctionContext *context, const StringVal & jsonVal, con
 
 #define selectValByToken(tok) { \
     rapidjson::Value& va = *currentVal;  \
-    if (va.HasMember(tok.c_str())) { \
-        currentVal = &(va[tok.c_str()]); \
+    rapidjson::Value key(rapidjson::StringRef(tok.c_str())); \
+    if (va.HasMember(key) { \
+        currentVal = &(va[key]); \
     } else { \
         /* context->AddWarning("no member"); */ \
         /* context->AddWarning(tok.c_str()); */ \


### PR DESCRIPTION
Fix for `select json_get_object('{"name":"steven"}', '$.name');` not returning `steven` but `NULL`.
