### PR TITLE
added support for backslash escape in selector

### DIFF
--- a/jsonUdf-test.cc
+++ b/jsonUdf-test.cc
@@ -34,13 +34,15 @@ int main(int argc, char** argv) {
   }
 
   {
-    const char * json = "{\"store\":{\"fruit\":[{\"weight\":8,\"type\":\"apple\"},{\"weight\":9,\"type\":\"pear\"}],\"bicycle\":{\"price\":19.95,\"color\":\"red\"}},\"email\":\"amy@only_for_json_udf_test.net\",\"owner\":\"amy\"}";
+    const char * json = "{\"store\":{\"fruit\":[{\"weight\":8,\"type\":\"apple\"},{\"weight\":9,\"type\":\"pear\"}],\"bicycle\":{\"price\":19.95,\"color\":\"red\"}},\"email\":\"amy@only_for_json_udf_test.net\",\"owner\":\"amy\",\"lang.iso 639-1\":\"en\"}";
     passed &= UdfTestHarness::ValidateUdf<StringVal, StringVal, StringVal>(
         JsonGetObject, StringVal(json), StringVal("$.owner"), StringVal("amy"));
     passed &= UdfTestHarness::ValidateUdf<StringVal, StringVal, StringVal>(
         JsonGetObject, StringVal(json), StringVal("$.store.fruit[0]"), StringVal("{\"weight\":8,\"type\":\"apple\"}"));
     passed &= UdfTestHarness::ValidateUdf<StringVal, StringVal, StringVal>(
         JsonGetObject, StringVal(json), StringVal("$.non_exist_key"), StringVal::null());
+    passed &= UdfTestHarness::ValidateUdf<StringVal, StringVal, StringVal>(
+        JsonGetObject, StringVal(json), StringVal("$.lang\\.iso 639-1"), StringVal("en"));
   }
 
   cout << "Tests " << (passed ? "Passed." : "Failed.") << endl;

--- a/jsonUdf.cc
+++ b/jsonUdf.cc
@@ -20,6 +20,7 @@
 // - output is always a String
 // - llvm udf works fine. .so udf wasn't tested
 // - selector is the same with hive get_json_object, except that * operator is not supported
+// - selector supports backslash escape for names with special chars (characters that should be escaped currently: '.$[]\')
 
 
 // we have to define this macro before <inttypes.h> is included 
@@ -128,6 +129,14 @@ StringVal JsonGetObject(FunctionContext *context, const StringVal & jsonVal, con
                 token.clear();
             }
             inBracket = false;
+            break;
+        case '\\':
+	    i++;
+            if (i >= selector.size()) {
+                context->SetError("encountered backslash at end of selector");
+                return StringVal::null();
+            }
+            token += pSel[i];
             break;
         default:
             token += pSel[i];


### PR DESCRIPTION
There was no way to query by names containing special chars, e.g. `{"a.b": 42}`, which is now possible with the backslash-escaped selector `$.a\.b` 

NOTE: the backslash itself is a special char for impala thus it needs to be escaped: 

``` sql
> SELECT json_get_object('{"a.b":42}', '$.a\\.b');
...
| 42
+----
```
